### PR TITLE
Fix types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadpool-ldap"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Aitor Ruano <codearm@pm.me>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ use deadpool_ldap::{Manager, Pool};
 
 #[tokio::main]
 async fn main() {
-    let manager = Manager("ldap://example.org");
+    let manager = Manager::new("ldap://example.org");
     let pool = Pool::new(manager, 5);
-        
+
     let mut client = pool.get().await.unwrap();
     result = client.simple_bind("uid=user,dc=example,dc=org", "password").await;
     assert!(result.is_ok());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,2 +1,0 @@
-pub use deadpool::managed::PoolError;
-pub use ldap3::LdapError;


### PR DESCRIPTION
0.1.4 does not work at all as the incorrect type was passed to Pool (deadpool 0.8 changes the contract).

This PR corrects that.

I also changes the storage type from 'static str to String so it is easier to use a dynamic string for the ldap URL (e.g. configuration loaded from config file or command line arguments).

This does change the use-contract slightly so instead of doing 
```rust
let manager = Manager("ldap://localhost/");
```
You now do this
```rust
let manager = Manager::new("ldap://localhost/");
```

::new() takes either 'str or String

(I've had these changes for a while locally. Finally pushing them up to get a released version up)