### PR TITLE
Feat deadpool 0 9 (and bump version to 0.3.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadpool-ldap"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Aitor Ruano <codearm@pm.me>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -12,7 +12,7 @@ keywords = ["ldap", "ldap3", "deadpool", "pool", "async"]
 
 [dependencies]
 ldap3 = { version = "0.9", default-features = false }
-deadpool = { version = "0.8", default-features = false, features = ["managed"] }
+deadpool = { version = "0.9", default-features = false, features = ["managed"] }
 actix-rt = { version = "2", optional = true }
 tokio = { version = "1.0", optional = true, features = [ "rt-multi-thread" ] }
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use deadpool_ldap::{Manager, Pool};
 #[tokio::main]
 async fn main() {
     let manager = Manager::new("ldap://example.org");
-    let pool = Pool::new(manager, 5);
+    let pool = Pool::builder(manager).max_size(5).build().unwrap();
 
     let mut client = pool.get().await.unwrap();
     result = client.simple_bind("uid=user,dc=example,dc=org", "password").await;
@@ -44,7 +44,7 @@ async fn main() {
             LdapConnSettings::new()
                 .set_conn_timeout(Duration::from_secs(30))
         );
-    let pool = Pool::new(manager, 5);
+    let pool = Pool::builder(manager).max_size(5).build().unwrap();
 
     let mut client = pool.get().await.unwrap();
     result = client.simple_bind("uid=user,dc=example,dc=org", "password").await;

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ async fn main() {
 }
 ```
 
+### Sending a custom LdapConnSettings
+
+To send custom ldap connection settings use .with_connection_settings() on the manager.
+
+```rust,ignore
+use deadpool_ldap::{Manager, Pool};
+use ldap3::LdapConnSettings;
+
+#[tokio::main]
+async fn main() {
+    let manager = Manager::new("ldap://example.org")
+        .with_connection_settings(
+            LdapConnSettings::new()
+                .set_conn_timeout(Duration::from_secs(30))
+        );
+    let pool = Pool::new(manager, 5);
+
+    let mut client = pool.get().await.unwrap();
+    result = client.simple_bind("uid=user,dc=example,dc=org", "password").await;
+    assert!(result.is_ok());
+}
+```
+
 ## License
 
 Licensed under either of
@@ -37,4 +60,3 @@ Licensed under either of
 * APACHE 2.0 license ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 
 Choose at your option!
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ impl deadpool::managed::Manager for Manager {
         #[cfg(feature = "rt-actix")]
         actix_rt::spawn(async move {
             if let Err(e) = conn.drive().await {
-                log::warn!("LDAP connection error: {}", e);
+                log::warn!("LDAP connection error: {:?}", e);
             }
         });
         Ok(ldap)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,22 @@
 use async_trait::async_trait;
-use ldap3::{exop::WhoAmI, Ldap, LdapConnAsync, LdapError};
+use ldap3::{exop::WhoAmI, Ldap, LdapConnAsync, LdapConnSettings, LdapError};
 
-pub struct Manager(String);
+pub struct Manager(String, LdapConnSettings);
 pub type Pool = deadpool::managed::Pool<Manager>;
 
+/// LDAP Manager for the `deadpool` managed connection pool.
 impl Manager {
+    /// Creates a new manager with the given URL.
+    /// URL can be anything that can go Into a String (e.g. String or &str)
     pub fn new<S: Into<String>>(ldap_url: S) -> Self {
-        Self(ldap_url.into())
+        Self(ldap_url.into(), LdapConnSettings::new())
+    }
+
+    /// Set a custom LdapConnSettings object on the manager.
+    /// Returns a copy of the Manager.
+    pub fn with_connection_settings(mut self, settings: LdapConnSettings) -> Self {
+        self.1 = settings;
+        self
     }
 }
 
@@ -16,7 +26,7 @@ impl deadpool::managed::Manager for Manager {
     type Error = LdapError;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let (conn, ldap) = LdapConnAsync::new(&self.0).await?;
+        let (conn, ldap) = LdapConnAsync::with_settings(self.1.clone(), &self.0).await?;
         #[cfg(feature = "default")]
         ldap3::drive!(conn);
         #[cfg(feature = "rt-actix")]
@@ -30,5 +40,57 @@ impl deadpool::managed::Manager for Manager {
     async fn recycle(&self, conn: &mut Self::Type) -> deadpool::managed::RecycleResult<Self::Error> {
         conn.extended(WhoAmI).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use super::*;
+
+    #[test]
+    fn manager_new_sets_url() {
+        let manager = Manager::new("my_url");
+
+        assert_eq!(manager.0, "my_url");
+    }
+
+    // TODO figure out how to test the LdapConnSettings struct
+
+    #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
+    #[test]
+    fn manager_new_sets_default_connection_settings() {
+        let manager = Manager::new("my_url");
+        let default = LdapConnSettings::new();
+
+        assert_eq!(manager.1.starttls(), default.starttls());
+    }
+
+    fn is_manager(s: &dyn std::any::Any) -> bool {
+        std::any::TypeId::of::<Manager>() == s.type_id()
+    }
+
+    #[test]
+    fn manager_with_connection_settings_returns_manager() {
+        let manager = Manager::new("my_url")
+            .with_connection_settings(
+                LdapConnSettings::new()
+                    .set_conn_timeout(Duration::from_secs(30))
+            );
+        assert!(is_manager(&manager));
+    }
+
+    #[cfg(any(feature = "tls-native", feature = "tls-rustls"))]
+    #[test]
+    fn manager_with_connection_settings_updates_settings() {
+        let manager = Manager::new("my_url")
+            .with_connection_settings(
+                LdapConnSettings::new()
+                    .set_conn_timeout(Duration::from_secs(30))
+                    .set_starttls(true)
+            );
+        let default = LdapConnSettings::new();
+
+        assert_ne!(manager.1.starttls(), default.starttls());
     }
 }


### PR DESCRIPTION
This depends on #4 and updated the deadpool dependency to 0.9 and upates the crate version to 0.3.0 (so 0.1.0 depends on deadpool 0.8 and 0.3.0 on deadpool 0.9)