### PR TITLE
update ldap3 to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["ldap", "ldap3", "deadpool", "pool", "async"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ldap3 = { version = "0.9", default-features = false }
+ldap3 = { version = "0.10", default-features = false }
 deadpool = { version = "0.9", default-features = false, features = ["managed"] }
 actix-rt = { version = "2", optional = true }
 tokio = { version = "1.0", optional = true, features = [ "rt-multi-thread" ] }


### PR DESCRIPTION
Bump the ldap3 dependency to its latest version v0.10

Tests pass

The following error is experienced using the newest ldap3 version:
~~~sh
mismatched types

expected struct `ldap3::conn::LdapConnSettings`, found struct `ldap3::LdapConnSettings`

note: perhaps two different versions of crate `ldap3` are being used?
~~~