### PR TITLE
Bumped dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["ldap", "ldap3", "deadpool", "pool", "async"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ldap3 = { version = "0.10", default-features = false }
+ldap3 = { version = "0.11", default-features = false }
 deadpool = { version = "0.9", default-features = false, features = ["managed"] }
 actix-rt = { version = "2", optional = true }
-tokio = { version = "1.0", optional = true, features = [ "rt-multi-thread" ] }
+tokio = { version = "1.27", optional = true, features = [ "rt-multi-thread" ] }
 async-trait = "0.1"
 log = "0.4"
 


### PR DESCRIPTION
Bumped [tokio](https://crates.io/crates/tokio) to `1.27.0` and [ldap3](https://crates.io/crates/ldap3) to 0.11.1

Tested and should work just fine